### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,36 +6,36 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ZeroMaster			KEYWORD1
+ZeroMaster	KEYWORD1
 
-ZeroLED      			KEYWORD1
-ZeroAMP      			KEYWORD1
-ZeroPWM      			KEYWORD1
-ZeroHeat			KEYWORD1
-ZeroFila			KEYWORD1
-Zero6675			KEYWORD1
-Zero31855			KEYWORD1
-ZeroBuzz			KEYWORD1
-ZeroColor			KEYWORD1
+ZeroLED	KEYWORD1
+ZeroAMP	KEYWORD1
+ZeroPWM	KEYWORD1
+ZeroHeat	KEYWORD1
+ZeroFila	KEYWORD1
+Zero6675	KEYWORD1
+Zero31855	KEYWORD1
+ZeroBuzz	KEYWORD1
+ZeroColor	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Shine   			KEYWORD2
-DigiShine   			KEYWORD2
-EXA	   			KEYWORD2
-Amps				KEYWORD2
-pwmWrite   			KEYWORD2
-Heat				KEYWORD2
-HeatFast			KEYWORD2
-HeatRegulate			KEYWORD2
-FilaRead			KEYWORD2
-FilaRead5			KEYWORD2
-HeatRead			KEYWORD2
-HeatRead2			KEYWORD2
-Pulse				KEYWORD2
-Set				KEYWORD2
-ChangeSetting		KEYWORD2
-Read				KEYWORD2
-ReadAll			KEYWORD2
+Shine	KEYWORD2
+DigiShine	KEYWORD2
+EXA	KEYWORD2
+Amps	KEYWORD2
+pwmWrite	KEYWORD2
+Heat	KEYWORD2
+HeatFast	KEYWORD2
+HeatRegulate	KEYWORD2
+FilaRead	KEYWORD2
+FilaRead5	KEYWORD2
+HeatRead	KEYWORD2
+HeatRead2	KEYWORD2
+Pulse	KEYWORD2
+Set	KEYWORD2
+ChangeSetting	KEYWORD2
+Read	KEYWORD2
+ReadAll	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords